### PR TITLE
Create total Pools for getting ProfitSharing APY for every chain, Fix chain icon size on Portfolio page.

### DIFF
--- a/src/components/AnalyticChart/index.js
+++ b/src/components/AnalyticChart/index.js
@@ -15,9 +15,9 @@ const recommendLinks = [
 ]
 
 const AnalyticChart = () => {
-  const { pools } = usePools()
+  const { totalPools } = usePools()
 
-  const farmProfitSharingPool = pools.find(
+  const farmProfitSharingPool = totalPools.find(
     pool => pool.id === SPECIAL_VAULTS.NEW_PROFIT_SHARING_POOL_ID,
   )
 

--- a/src/components/ProfitSharing/index.js
+++ b/src/components/ProfitSharing/index.js
@@ -1,14 +1,8 @@
-import React, { useState, useEffect, useMemo } from 'react'
+import React, { useState, useEffect } from 'react'
 import { useHistory } from 'react-router-dom'
-import { displayAPY, getTotalApy, getDataQuery } from '../../utils'
-import {
-  FARM_TOKEN_SYMBOL,
-  SPECIAL_VAULTS,
-  DECIMAL_PRECISION,
-  directDetailUrl,
-} from '../../constants'
+import { getDataQuery } from '../../utils'
+import { directDetailUrl } from '../../constants'
 import { useStats } from '../../providers/Stats'
-import { usePools } from '../../providers/Pools'
 import { useWallet } from '../../providers/Wallet'
 import SmallApexChart from '../SmallApexChart'
 import { addresses } from '../../data/index'
@@ -17,26 +11,9 @@ import ProfitSharingIcon from '../../assets/images/logos/sidebar/profit-sharing.
 import ProfitSharingTitle from '../../assets/images/logos/sidebar/profit-sharing-title.svg'
 
 const ProfitSharingContainer = ({ height }) => {
-  const { pools } = usePools()
   const { chainId } = useWallet()
   const { profitShareAPY } = useStats()
   const { push } = useHistory()
-  const farmProfitSharingPool = pools.find(
-    pool => pool.id === SPECIAL_VAULTS.NEW_PROFIT_SHARING_POOL_ID,
-  )
-  const poolVaults = useMemo(
-    () => ({
-      [FARM_TOKEN_SYMBOL]: {
-        poolVault: true,
-        profitShareAPY,
-        data: farmProfitSharingPool,
-        logoUrl: ['./icons/ifarm.svg'],
-      },
-    }),
-    [profitShareAPY, farmProfitSharingPool],
-  )
-  const token = poolVaults.FARM
-  const totalApy = getTotalApy(null, token, true)
 
   const [apiData, setApiData] = useState({})
   useEffect(() => {
@@ -60,11 +37,11 @@ const ProfitSharingContainer = ({ height }) => {
       </TopDiv>
       <BottomDiv>
         <div className="apy">
-          {displayAPY(totalApy, DECIMAL_PRECISION, 10)}
-          &nbsp;APR
+          {Number(profitShareAPY).toFixed(2)}
+          %&nbsp;APR
         </div>
         <div className="chart">
-          <SmallApexChart data={apiData} lastAPY={Number(totalApy)} />
+          <SmallApexChart data={apiData} lastAPY={Number(profitShareAPY)} />
         </div>
       </BottomDiv>
     </ProfitSharing>

--- a/src/components/Sidebar/index.js
+++ b/src/components/Sidebar/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment, useEffect, useMemo, useState } from 'react'
+import React, { Fragment, useEffect, useState } from 'react'
 import { Dropdown, Offcanvas } from 'react-bootstrap'
 import { useHistory, useLocation } from 'react-router-dom'
 import Analytics from '../../assets/images/logos/sidebar/analytics.svg'
@@ -18,27 +18,14 @@ import Toggle from '../../assets/images/logos/sidebar/toggle.svg'
 import Arbitrum from '../../assets/images/chains/arbitrum.svg'
 import Ethereum from '../../assets/images/chains/ethereum.svg'
 import Polygon from '../../assets/images/chains/polygon.svg'
-import {
-  DECIMAL_PRECISION,
-  FARM_TOKEN_SYMBOL,
-  ROUTES,
-  SPECIAL_VAULTS,
-  directDetailUrl,
-} from '../../constants'
+import { ROUTES, directDetailUrl } from '../../constants'
 import { CHAINS_ID } from '../../data/constants'
 import { addresses } from '../../data/index'
 import { usePools } from '../../providers/Pools'
 import { useStats } from '../../providers/Stats'
 import { useThemeContext } from '../../providers/useThemeContext'
 import { useWallet } from '../../providers/Wallet'
-import {
-  displayAPY,
-  formatAddress,
-  getDataQuery,
-  getTotalApy,
-  isLedgerLive,
-  isSafeApp,
-} from '../../utils'
+import { formatAddress, getDataQuery, isLedgerLive, isSafeApp } from '../../utils'
 import SmallApexChart from '../SmallApexChart'
 import Social from '../Social'
 import {
@@ -173,7 +160,7 @@ const getChainIcon = chainNum => {
 
 const Sidebar = ({ width }) => {
   const { account, connectAction, disconnectAction, chainId, connected, setSelChain } = useWallet()
-  const { pools, disableWallet } = usePools()
+  const { disableWallet } = usePools()
   const { profitShareAPY } = useStats()
 
   const {
@@ -211,25 +198,6 @@ const Sidebar = ({ width }) => {
   const handleMobileClose = () => setMobileShow(false)
   const handleMobileShow = () => setMobileShow(true)
 
-  const farmProfitSharingPool = pools.find(
-    pool => pool.id === SPECIAL_VAULTS.NEW_PROFIT_SHARING_POOL_ID,
-  )
-
-  const poolVaults = useMemo(
-    () => ({
-      [FARM_TOKEN_SYMBOL]: {
-        poolVault: true,
-        profitShareAPY,
-        data: farmProfitSharingPool,
-        logoUrl: ['./icons/ifarm.svg'],
-      },
-    }),
-    [profitShareAPY, farmProfitSharingPool],
-  )
-  const token = poolVaults.FARM
-
-  const totalApy = getTotalApy(null, token, true)
-
   const [apiData, setApiData] = useState({})
   useEffect(() => {
     const initData = async () => {
@@ -240,7 +208,7 @@ const Sidebar = ({ width }) => {
   }, [chainId])
 
   const directAction = path => {
-    if (path === ROUTES.PORTFOLIO || path === ROUTES.ANALYTIC) {
+    if (path === ROUTES.PORTFOLIO) {
       setSelChain([CHAINS_ID.ETH_MAINNET, CHAINS_ID.MATIC_MAINNET, CHAINS_ID.ARBITRUM_ONE])
     }
     push(path)
@@ -414,11 +382,10 @@ const Sidebar = ({ width }) => {
             </TopTitle>
           </TopDiv>
           <BottomDiv>
-            {displayAPY(totalApy, DECIMAL_PRECISION, 10)}
-            <div>APR</div>
+            {Number(profitShareAPY).toFixed(2)}%<div>APR</div>
           </BottomDiv>
           <ChartDiv>
-            <SmallApexChart data={apiData} lastAPY={Number(totalApy)} />
+            <SmallApexChart data={apiData} lastAPY={Number(profitShareAPY)} />
           </ChartDiv>
         </ProfitSharing>
 
@@ -633,11 +600,10 @@ const Sidebar = ({ width }) => {
                   </TopTitle>
                 </TopDiv>
                 <BottomDiv>
-                  {displayAPY(totalApy, DECIMAL_PRECISION, 10)}
-                  <div>APR</div>
+                  {Number(profitShareAPY).toFixed(2)}%<div>APR</div>
                 </BottomDiv>
                 <ChartDiv>
-                  <SmallApexChart data={apiData} lastAPY={Number(totalApy)} />
+                  <SmallApexChart data={apiData} lastAPY={Number(profitShareAPY)} />
                 </ChartDiv>
               </MobileProfitSharing>
             </ProfitPart>

--- a/src/pages/Portfolio/index.js
+++ b/src/pages/Portfolio/index.js
@@ -97,7 +97,7 @@ const chainList = isLedgerLive()
 const Portfolio = () => {
   const { push } = useHistory()
   const { connected, balances, account, getWalletBalances } = useWallet()
-  const { userStats, fetchUserPoolStats, pools } = usePools()
+  const { userStats, fetchUserPoolStats, totalPools } = usePools()
   const { profitShareAPY } = useStats()
   const { vaultsData, farmingBalances, getFarmingBalances } = useVaults()
   /* eslint-disable global-require */
@@ -118,11 +118,11 @@ const Portfolio = () => {
 
   const [switchBalance, setSwitchBalance] = useState(false)
 
-  const farmProfitSharingPool = pools.find(
+  const farmProfitSharingPool = totalPools.find(
     pool => pool.id === SPECIAL_VAULTS.NEW_PROFIT_SHARING_POOL_ID,
   )
-  const farmWethPool = pools.find(pool => pool.id === SPECIAL_VAULTS.FARM_WETH_POOL_ID)
-  const farmGrainPool = pools.find(pool => pool.id === SPECIAL_VAULTS.FARM_GRAIN_POOL_ID)
+  const farmWethPool = totalPools.find(pool => pool.id === SPECIAL_VAULTS.FARM_WETH_POOL_ID)
+  const farmGrainPool = totalPools.find(pool => pool.id === SPECIAL_VAULTS.FARM_GRAIN_POOL_ID)
   const poolVaults = useMemo(
     () => ({
       [FARM_TOKEN_SYMBOL]: {
@@ -216,7 +216,7 @@ const Portfolio = () => {
           let fAssetPool =
             depositToken[i] === FARM_TOKEN_SYMBOL
               ? groupOfVaults[depositToken[i]].data
-              : find(pools, pool => pool.id === depositToken[i])
+              : find(totalPools, pool => pool.id === depositToken[i])
 
           const token = find(
             groupOfVaults,
@@ -238,7 +238,7 @@ const Portfolio = () => {
       }
       loadUserPoolsStats()
     }
-  }, [account, pools, depositToken]) // eslint-disable-line react-hooks/exhaustive-deps
+  }, [account, totalPools, depositToken]) // eslint-disable-line react-hooks/exhaustive-deps
 
   useEffect(() => {
     if (!isEmpty(userStats) && account) {
@@ -292,7 +292,7 @@ const Portfolio = () => {
           let fAssetPool =
             symbol === FARM_TOKEN_SYMBOL
               ? groupOfVaults[symbol].data
-              : find(pools, pool => pool.id === symbol)
+              : find(totalPools, pool => pool.id === symbol)
 
           const token = find(
             groupOfVaults,

--- a/src/pages/Portfolio/index.js
+++ b/src/pages/Portfolio/index.js
@@ -569,7 +569,7 @@ const Portfolio = () => {
                       <FlexDiv>
                         <Content width="5%" firstColumn>
                           <BadgeIcon badgeBack={badgeIconBackColor}>
-                            <img src={info.chain} width="10px" height="10px" alt="" />
+                            <img src={info.chain} width="15px" height="15px" alt="" />
                           </BadgeIcon>
                         </Content>
                         <Content
@@ -582,7 +582,7 @@ const Portfolio = () => {
                                 <LogoImg
                                   key={index}
                                   className="coin"
-                                  width={isMobile ? 19 : 37}
+                                  width={isMobile ? 30 : 37}
                                   src={elem}
                                   alt=""
                                 />

--- a/src/pages/Portfolio/style.js
+++ b/src/pages/Portfolio/style.js
@@ -239,8 +239,8 @@ const Content = styled.div`
 `
 
 const BadgeIcon = styled.div`
-  width: 14px;
-  height: 15px;
+  width: 21px;
+  height: 22px;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/src/providers/Pools/index.js
+++ b/src/providers/Pools/index.js
@@ -50,6 +50,7 @@ const PoolsProvider = _ref => {
   const { account, selChain, chainId, balances: walletBalances, logout } = useWallet()
   const { contracts } = useContracts()
   const [pools, setPools] = useState(defaultPools)
+  const [totalPools, setTotalPools] = useState(defaultPools)
   const [userStats, setUserStats] = useState([])
   const [vaultLoading, setVaultLoading] = useState(true)
   const [loadingUserPoolStats, setLoadingUserPoolStats] = useState(false)
@@ -220,6 +221,7 @@ const PoolsProvider = _ref => {
     }
 
     setPools(newPools)
+    setTotalPools(newPools)
     setFinishPool(true)
   }, [formatPoolsData])
 
@@ -445,6 +447,7 @@ const PoolsProvider = _ref => {
         vaultLoading,
         setVaultLoading,
         disableWallet,
+        totalPools,
       },
     },
     children,

--- a/src/providers/Stats.js
+++ b/src/providers/Stats.js
@@ -38,13 +38,16 @@ const StatsProvider = ({ children }) => {
   })
 
   const { contracts } = useContracts()
-  const { pools } = usePools()
+  const { totalPools } = usePools()
 
   const firstStatsRender = useRef(true)
 
   useEffect(() => {
     const fetchStats = async () => {
-      const farmPool = find(pools, pool => pool.id === SPECIAL_VAULTS.NEW_PROFIT_SHARING_POOL_ID)
+      const farmPool = find(
+        totalPools,
+        pool => pool.id === SPECIAL_VAULTS.NEW_PROFIT_SHARING_POOL_ID,
+      )
       if (contracts.FARM && farmPool && farmPool.loaded) {
         firstStatsRender.current = false
 
@@ -87,7 +90,7 @@ const StatsProvider = ({ children }) => {
     if (firstStatsRender.current) {
       fetchStats()
     }
-  }, [contracts.FARM, pools])
+  }, [contracts.FARM, totalPools])
 
   return <StatsContext.Provider value={{ ...stats }}>{children}</StatsContext.Provider>
 }


### PR DESCRIPTION
It is needed to get total pools that be not related chain selection.
When user doesn't select Ethereum network on Home page, Profit Sharing APY on Sidebar doesn't show.
So I created totalPools for that.